### PR TITLE
Added tiered compilation

### DIFF
--- a/cdk/src/main/java/airhacks/functionurl/boundary/FunctionURLStack.java
+++ b/cdk/src/main/java/airhacks/functionurl/boundary/FunctionURLStack.java
@@ -13,8 +13,8 @@ public class FunctionURLStack extends Stack {
 
     public FunctionURLStack(Construct construct,String id) {
         super(construct,id+ "-function-url-stack");
-        var quarkuLambda = new QuarkusLambda(this, FUNCTION_NAME);
-        var function = quarkuLambda.getFunction();
+        var quarkusLambda = new QuarkusLambda(this, FUNCTION_NAME);
+        var function = quarkusLambda.getFunction();
         var functionUrl = function.addFunctionUrl(FunctionUrlOptions.builder()
                 .authType(FunctionUrlAuthType.NONE)
                 .build());

--- a/cdk/src/main/java/airhacks/lambda/control/QuarkusLambda.java
+++ b/cdk/src/main/java/airhacks/lambda/control/QuarkusLambda.java
@@ -12,7 +12,9 @@ import software.constructs.Construct;
 
 public class QuarkusLambda extends Construct{
 
-    static Map<String, String> configuration = Map.of("message", "hello, quarkus as AWS Lambda");
+    static Map<String, String> configuration = Map.of(
+            "message", "hello, quarkus as AWS Lambda",
+            "JAVA_TOOL_OPTIONS", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1");
     static String lambdaHandler = "io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest";
     static int memory = 1024; //~0.5 vCPU
     static int timeout = 10;


### PR DESCRIPTION
Hi Adam,

adding tiered compilation to the function reduces your cold starts by around 1 second. You can find a benchmark between tiered and non-tiered compilation below. Test was done doing 10 concurrent requests per second for 60 seconds.

With tiered compilation (0 means warm start, 1 means cold start):
![tiered](https://user-images.githubusercontent.com/36627945/181361700-348a484b-2f3a-48a1-90c3-cea5b603862e.png)

Without tiered compilation:

![no_tiered](https://user-images.githubusercontent.com/36627945/181361635-8546d86b-1dfd-4164-a30a-528da6a357f6.png)



More infos also [here](https://aws.amazon.com/de/blogs/compute/optimizing-aws-lambda-function-performance-for-java/).

Best,
Max